### PR TITLE
21 doc update documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,26 +2,16 @@
 
 Synthetic experiment data for testing AutoRA theorists and experimentalists. 
 
-## Quickstart Guide
+## Overview
 
-You will need:
+| Name | Category | Links |
+|---|---|---|
+| Linear mixed model | Abstract | [Ref](https://autoresearch.github.io/autora/reference/autora/experiment_runner/synthetic/abstract/llm/) |
+| Expected Value Theory | Economics | [Ref](https://autoresearch.github.io/autora/reference/autora/experiment_runner/synthetic/economics/expected_value_theory/) |
+| Prospect theory | Economics | [Ref](https://autoresearch.github.io/autora/reference/autora/experiment_runner/synthetic/economics/prospect_theory/) |
+| Task Switching | Neuroscience | [Ref](https://autoresearch.github.io/autora/reference/autora/experiment_runner/synthetic/neuroscience/task_switching/) |
+| Exponential Learning | Psychology | [Ref](https://autoresearch.github.io/autora/reference/autora/experiment_runner/synthetic/psychology/exp_learning/) |
+| Luce-Choice-Ratio | Psychology | [Ref](https://autoresearch.github.io/autora/reference/autora/experiment_runner/synthetic/psychology/luce_choice_ratio/) |
+| Stevens' Power Law | Psychophysics | [Ref](https://autoresearch.github.io/autora/reference/autora/experiment_runner/synthetic/psychophysics/stevens_power_law/) |
+| Weber-Fechner Law | Psychophysics | [Ref](https://autoresearch.github.io/autora/reference/autora/experiment_runner/synthetic/psychophysics/weber_fechner_law/) |
 
-- `python` 3.8 or greater: [https://www.python.org/downloads/](https://www.python.org/downloads/)
-
-Install the synthetic data package:
-
-```shell
-pip install -U "autora"
-```
-
-!!! success
-    It is recommended to use a `python` environment manager like `virtualenv`.
-
-Print a description of the prospect theory model by Kahneman and Tversky by running:
-```shell
-python -c "
-from autora.experiment_runner.synthetic.economics.prospect_theory import prospect_theory
-study = prospect_theory()
-print(study.description)
-"
-```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,23 @@
+# Quickstart Guide
+
+You will need:
+
+- `python` 3.8 or greater: [https://www.python.org/downloads/](https://www.python.org/downloads/)
+
+Most synthetic experiment runners are part of autora-core:
+
+```shell
+pip install -U "autora"
+```
+
+!!! success
+    It is recommended to use a `python` environment manager like `virtualenv`.
+
+Print a description of the prospect theory model by Kahneman and Tversky by running:
+```shell
+python -c "
+from autora.experiment_runner.synthetic.economics.prospect_theory import prospect_theory
+study = prospect_theory()
+print(study.description)
+"
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,5 +5,6 @@ site_name: AutoRA Synthetic Data
 repo_url: 'https://github.com/AutoResearch/autora-synthetic'
 
 nav:
-- Introduction: 'index.md'
+- Home: 'index.md'
+- Quickstart: 'quickstart.md'
 - Example: 'Example.ipynb'

--- a/src/autora/experiment_runner/synthetic/neuroscience/task_switching.py
+++ b/src/autora/experiment_runner/synthetic/neuroscience/task_switching.py
@@ -17,7 +17,7 @@ def task_switching(
     constant=1.5,
 ):
     """
-    Task Switchng
+    Task Switching
 
     Args:
         name: name of the experiment


### PR DESCRIPTION
# Description

make a (tiny) little bot more documentation

resolves #21 

# Type of change

- **docs**: Documentation only changes

Questions/Ideas:
I think we should eventually move the documentation to the autora-parent package instead of here. Allthough that is a bit inconvienient since code and documentaiton is in seperate repositories, we might end up linkning to parts of the documentation from other packages (for example core). In fact, this already happens here: the ref links are not in this repository but in the autora-parent repo.
Also: that will make it easier to seamlessly add optional synthetic runners to the documentation (I think the documentation of them should not be included here at all).