### PR TITLE
docs: update links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,12 +6,13 @@ Synthetic experiment data for testing AutoRA theorists and experimentalists.
 
 | Name | Category | Links |
 |---|---|---|
-| Linear mixed model | Abstract | [Ref](https://autoresearch.github.io/autora/reference/autora/experiment_runner/synthetic/abstract/llm/) |
+| Linear mixed model | Abstract | [Ref](https://autoresearch.github.io/autora/reference/autora/experiment_runner/synthetic/abstract/lmm/) |
 | Expected Value Theory | Economics | [Ref](https://autoresearch.github.io/autora/reference/autora/experiment_runner/synthetic/economics/expected_value_theory/) |
 | Prospect theory | Economics | [Ref](https://autoresearch.github.io/autora/reference/autora/experiment_runner/synthetic/economics/prospect_theory/) |
 | Task Switching | Neuroscience | [Ref](https://autoresearch.github.io/autora/reference/autora/experiment_runner/synthetic/neuroscience/task_switching/) |
 | Exponential Learning | Psychology | [Ref](https://autoresearch.github.io/autora/reference/autora/experiment_runner/synthetic/psychology/exp_learning/) |
 | Luce-Choice-Ratio | Psychology | [Ref](https://autoresearch.github.io/autora/reference/autora/experiment_runner/synthetic/psychology/luce_choice_ratio/) |
+| Q-Learning | Psychology | [Ref](https://autoresearch.github.io/autora/reference/autora/experiment_runner/synthetic/psychology/q_learning/) |
 | Stevens' Power Law | Psychophysics | [Ref](https://autoresearch.github.io/autora/reference/autora/experiment_runner/synthetic/psychophysics/stevens_power_law/) |
 | Weber-Fechner Law | Psychophysics | [Ref](https://autoresearch.github.io/autora/reference/autora/experiment_runner/synthetic/psychophysics/weber_fechner_law/) |
 


### PR DESCRIPTION
# Description

fix link for lmm and add link for q-learning

*If the issue is on Github, simply link to it using the '#' symbol; otherwise, provide a notion page link)*:
- resolves #29

# Type of change

- **docs**: Documentation only changes
